### PR TITLE
Add example .desktop entries to integrate into DE

### DIFF
--- a/example .desktop/NearShare-receive.desktop
+++ b/example .desktop/NearShare-receive.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+#desktop entry to advertise Windows Nearby share capability and receive files to ~/Downloads/
+Name=Nearby Share - Receive
+#executable can be obtained from https://github.com/nearby-sharing/cli
+Exec=/usr/local/bin/NearShare receive --path ~/Downloads/
+Type=Application
+Categories=Utility
+Icon=mail-receive
+Terminal=true
+NoDisplay=false
+#allow ports 5040/tcp and 5050/udp

--- a/example .desktop/NearShare-sendClipboard.desktop
+++ b/example .desktop/NearShare-sendClipboard.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+#desktop entry to use Windows Nearby share capability to send last clipboard entry using wl-paste
+Name=Nearby Share - Send last clipboard entry...
+#executable can be obtained from https://github.com/nearby-sharing/cli
+Exec=/usr/local/bin/NearShare send --url "$(wl-paste -n -t 'text/plain;charset=utf-8')"
+#will silently fail if last clipboard entry is not text
+Type=Application
+Categories=Utility
+Icon=edit-paste-symbolic
+Terminal=true
+TerminalOptions=\s--noclose
+NoDisplay=false

--- a/example .desktop/NearShare-sendFile.desktop
+++ b/example .desktop/NearShare-sendFile.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+#KDE: place in ~/.local/share/kio/servicemenus/ to show in context menu
+Type=Service
+Actions=file;
+MimeType=all/allfiles;
+#X-KDE-Submenu=Nearby Share
+Terminal=true
+#TerminalOptions=\s--noclose
+
+[Desktop Action file]
+Name=Nearby share file...
+#place NearShare execuable in bin path i.e. /usr/local/bin/
+Exec=NearShare send --file %f
+Icon=preferences-system-network-share-windows


### PR DESCRIPTION
This is a series of .desktop files I use to integrate NearShare into my DE

Included are:
- Application menu entry to receive
- Application menu entry to send clipboard (url only)
- KDE servicemenu entry to send any file from context menu
 
The Microsoft "share" icon is not used as it may be trademarked.
Icons are taken from standard KDE icon set